### PR TITLE
Addinf ReplaceServices and TryRegister to RegistrationContext

### DIFF
--- a/src/Agoda.IoC.Core/ContainerRegistrationAttributes.cs
+++ b/src/Agoda.IoC.Core/ContainerRegistrationAttributes.cs
@@ -142,6 +142,16 @@ namespace Agoda.IoC.Core
         [Obsolete("Use only for legacy registrations migrated from the RegisterRepository() or RegisterService() Unity " +
                   "extensions. For new code use ServerSideTimer.")]
         public bool LegacyMeasured { get; set; }
+
+        /// <summary>
+        /// Set true to replace services if they are already registered before. Uses Replace extension method of IServiceCollection.
+        /// </summary>
+        public bool ReplaceServices { get; set; }
+
+        /// <summary>
+        /// Set true to register the service only if it's not registered before. Uses TryAdd... extension methods of IServiceCollection.
+        /// </summary>
+        public bool TryRegister { get; set; } 
     }
 
     /// <inheritdoc />

--- a/src/Agoda.IoC.NetCore/StartupExtension.cs
+++ b/src/Agoda.IoC.NetCore/StartupExtension.cs
@@ -1,5 +1,6 @@
 ﻿using Agoda.IoC.Core;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -82,7 +83,19 @@ namespace Agoda.IoC.NetCore
                 }
                 else
                 {
-                    services.Add(new ServiceDescriptor(reg.FromType, toType, serviceLifetime));
+                    var serviceDescriptor =  new ServiceDescriptor(reg.FromType, toType, serviceLifetime);
+                    if (reg.Attribute?.ReplaceServices == true)
+                    {
+                        services.Replace(serviceDescriptor);
+                    }
+                    else if (reg.Attribute?.TryRegister == true)
+                    {
+                        services.TryAdd(serviceDescriptor);
+                    }
+                    else
+                    {
+                        services.Add(serviceDescriptor);
+                    }                    
                 }
 
             }


### PR DESCRIPTION
Adding 2 properties to RegistrationContext
1. ReplaceServices: Set true to replace services if they are already registered before. Uses Replace extension method of IServiceCollection.
``` C#
 [RegisterSingleton(Mock = typeof(ConsumerMockSmartService), For = typeof(ISmartService), ReplaceServices = true)]
    public class ConsumerSmartService : ISmartService
    {
        public string DoSomeThing() => "ConsumerSmartService";
    }

    public class ConsumerMockSmartService : ISmartService
    {
        public string DoSomeThing() => "ConsumerMockSmartService";
    }

```


2. TryRegister : Set true to register the service only if it's not registered before. Uses TryAdd... extension methods of IServiceCollection.
    
``` C#
 [RegisterSingleton(Mock = typeof(ConsumerMockSmartService), For = typeof(ISmartService), TryRegister = true)]
    public class ConsumerSmartService : ISmartService
    {
        public string DoSomeThing() => "ConsumerSmartService";
    }

    public class ConsumerMockSmartService : ISmartService
    {
        public string DoSomeThing() => "ConsumerMockSmartService";
    }

```