### PR TITLE
Adding feature to replace registered service in IoC

### DIFF
--- a/src/Agoda.IoC.Core/ContainerRegistrationAttributes.cs
+++ b/src/Agoda.IoC.Core/ContainerRegistrationAttributes.cs
@@ -137,7 +137,12 @@ namespace Agoda.IoC.Core
         /// Only types of a single generic argument are supported, which is enough for our use case.
         /// </remarks>
         public Type GenericArgument { get; set; }
-        
+
+        /// <summary>
+        /// ReplaceServices: Set true to replace services if they are already registered before. Uses Replace extension method of IServiceCollection.
+        /// </summary>
+        public bool ReplaceServices { get; set; }
+
         //[EditorBrowsable(EditorBrowsableState.Never)] // uncomment this once all registrations are migrated
         [Obsolete("Use only for legacy registrations migrated from the RegisterRepository() or RegisterService() Unity " +
                   "extensions. For new code use ServerSideTimer.")]

--- a/src/Agoda.IoC.Core/RegistrationContext.cs
+++ b/src/Agoda.IoC.Core/RegistrationContext.cs
@@ -15,6 +15,8 @@ namespace Agoda.IoC.Core
         public Type FactoryType { get; private set; }
         public ContainerRegistrationAttribute Attribute { get; }
         public bool IsIntercepted { get; }
+
+        public bool ReplaceServices { get; }
         public (bool IsValid, string ErrorMessage) Validation { get; }
 
         private readonly IList<Type> _baseTypes;
@@ -35,9 +37,9 @@ namespace Agoda.IoC.Core
             FactoryType = (mockMode && MockType != null) ? null : attribute.Factory;
             Collection = (attribute.OfCollection, attribute.Order);
             Key = attribute.Key?.ToString();
+            ReplaceServices = attribute.ReplaceServices;
             IsIntercepted = wrapper?.HasInterceptors(this) ?? false;
-            _genericArgument = Attribute.GenericArgument;
-            
+            _genericArgument = attribute.GenericArgument;            
             _baseTypes = ContainerAttributeUtils.GetBaseTypes(attribute, toType).ToList();
             
             // we might have to fiddle with the ToType to keep Unity happy, so we keep a copy of the original for error reporting

--- a/src/Agoda.IoC.NetCore.UnitTests/Agoda.IoC.NetCore.UnitTests.csproj
+++ b/src/Agoda.IoC.NetCore.UnitTests/Agoda.IoC.NetCore.UnitTests.csproj
@@ -29,6 +29,7 @@
 		<ProjectReference Include="..\Agoda.IoC.Core\Agoda.IoC.Core.csproj" />
 		<ProjectReference Include="..\Agoda.IoC.NetCore\Agoda.IoC.NetCore.csproj" />
 		<ProjectReference Include="..\ProjectsUnderTest\Agoda.IoC.ProjectUnderTest.Invalid12\Agoda.IoC.ProjectUnderTest.Invalid12.csproj" />
+		<ProjectReference Include="..\ProjectsUnderTest\Agoda.IoC.ProjectUnderTest.Valid2\Agoda.IoC.ProjectUnderTest.Valid2.csproj" />
 		<ProjectReference Include="..\ProjectsUnderTest\Agoda.IoC.ProjectUnderTest.Valid\Agoda.IoC.ProjectUnderTest.Valid.csproj" />
 	</ItemGroup>
 </Project>

--- a/src/Agoda.IoC.NetCore.UnitTests/MicrosoftExtensionsDependencyInjectionAutowireTests.cs
+++ b/src/Agoda.IoC.NetCore.UnitTests/MicrosoftExtensionsDependencyInjectionAutowireTests.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Agoda.IoC.ProjectUnderTest.Valid;
+using Agoda.IoC.ProjectUnderTest.Valid2;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 using Shouldly;
@@ -21,7 +22,8 @@ namespace Agoda.IoC.NetCore.UnitTests
             _container = new ServiceCollection();
             _container.AutoWireAssembly(new[]
             {
-                typeof(NoAttribute).Assembly
+                typeof(NoAttribute).Assembly,
+                typeof(ReplaceServiceTwoWork).Assembly,
             }, false);
             _containerMocked = new ServiceCollection();
             _containerMocked.AutoWireAssembly(new[]
@@ -34,8 +36,8 @@ namespace Agoda.IoC.NetCore.UnitTests
         public void LookforAutowire_ConcreteImplementation()
         {
             _container
-                .Any(x=>
-                    x.ServiceType == typeof(ConcreteImplementation) 
+                .Any(x =>
+                    x.ServiceType == typeof(ConcreteImplementation)
                     && x.Lifetime == ServiceLifetime.Scoped)
                 .ShouldBeTrue();
         }
@@ -237,6 +239,18 @@ namespace Agoda.IoC.NetCore.UnitTests
                     x.ServiceType == typeof(KeyedFactoryService2)
                     && x.Lifetime == ServiceLifetime.Scoped)
                 .ShouldBeTrue();
+        }
+
+        [Test]
+        public void LookforAutowire_ReplaceServiceChecks()
+        {
+            _container
+                .Any(x =>
+                    x.ServiceType == typeof(IReplaceService)
+                    && x.ImplementationType == typeof(ReplaceServiceTwoWork)
+                    && x.Lifetime == ServiceLifetime.Transient)
+                .ShouldBeTrue();
+           
         }
     }
 }

--- a/src/Agoda.IoC.sln
+++ b/src/Agoda.IoC.sln
@@ -53,6 +53,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Agoda.IoC.ProjectUnderTest.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Agoda.IoC.ProjectUnderTest.Valid", "ProjectsUnderTest\Agoda.IoC.ProjectUnderTest.Valid\Agoda.IoC.ProjectUnderTest.Valid.csproj", "{F5BB7380-859D-4087-AA35-58203D9614BF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Agoda.IoC.ProjectUnderTest.Valid2", "ProjectsUnderTest\Agoda.IoC.ProjectUnderTest.Valid2\Agoda.IoC.ProjectUnderTest.Valid2.csproj", "{4F9A3CE2-B770-4FBB-ACBD-A4E94839C26B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -155,6 +157,10 @@ Global
 		{F5BB7380-859D-4087-AA35-58203D9614BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F5BB7380-859D-4087-AA35-58203D9614BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F5BB7380-859D-4087-AA35-58203D9614BF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F9A3CE2-B770-4FBB-ACBD-A4E94839C26B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F9A3CE2-B770-4FBB-ACBD-A4E94839C26B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4F9A3CE2-B770-4FBB-ACBD-A4E94839C26B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4F9A3CE2-B770-4FBB-ACBD-A4E94839C26B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -179,6 +185,7 @@ Global
 		{B4E96AC2-8C6F-467D-9864-63C3AAE2A602} = {A1AA9098-0B0E-45B4-84E9-8EE4E3860688}
 		{1758456F-230D-4A2B-89AD-A204BA1B68A4} = {A1AA9098-0B0E-45B4-84E9-8EE4E3860688}
 		{F5BB7380-859D-4087-AA35-58203D9614BF} = {A1AA9098-0B0E-45B4-84E9-8EE4E3860688}
+		{4F9A3CE2-B770-4FBB-ACBD-A4E94839C26B} = {A1AA9098-0B0E-45B4-84E9-8EE4E3860688}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {96108C8B-1CFE-440B-9A38-213FAFE10220}

--- a/src/ProjectsUnderTest/Agoda.IoC.ProjectUnderTest.Valid/ValidRegistrations.cs
+++ b/src/ProjectsUnderTest/Agoda.IoC.ProjectUnderTest.Valid/ValidRegistrations.cs
@@ -246,4 +246,18 @@ namespace Agoda.IoC.ProjectUnderTest.Valid
         public string BuiltBy { get; set; }
     }
     
+
+    public interface IReplaceService
+    {
+        string DoWork { get; set; }
+    }
+
+    [RegisterTransient]
+    public class ReplaceServiceOneWork : IReplaceService
+    {
+        public string DoWork { get; set; } = nameof(ReplaceServiceOneWork);
+    }
+
+
+
 }

--- a/src/ProjectsUnderTest/Agoda.IoC.ProjectUnderTest.Valid2/Agoda.IoC.ProjectUnderTest.Valid2.csproj
+++ b/src/ProjectsUnderTest/Agoda.IoC.ProjectUnderTest.Valid2/Agoda.IoC.ProjectUnderTest.Valid2.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<RootNamespace>Agoda.IoC.ProjectUnderTest.Valid2</RootNamespace>
+		<AssemblyName>Agoda.IoC.ProjectUnderTest.Valid2</AssemblyName>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<AssemblyTitle>Agoda.IoC.ProjectUnderTest.Valid2</AssemblyTitle>
+		<Product>Agoda.IoC.ProjectUnderTest.Valid2</Product>
+		<Copyright>Copyright ©  2018</Copyright>
+		<IsPackable>false</IsPackable>
+		<OutputPath>bin\$(Configuration)\</OutputPath>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<DebugType>full</DebugType>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DebugType>pdbonly</DebugType>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Agoda.Analyzers" Version="1.0.504">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\Agoda.IoC.Core\Agoda.IoC.Core.csproj" />
+		<ProjectReference Include="..\Agoda.IoC.ProjectUnderTest.Valid\Agoda.IoC.ProjectUnderTest.Valid.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/ProjectsUnderTest/Agoda.IoC.ProjectUnderTest.Valid2/ValidRegistrations2.cs
+++ b/src/ProjectsUnderTest/Agoda.IoC.ProjectUnderTest.Valid2/ValidRegistrations2.cs
@@ -1,0 +1,14 @@
+﻿using Agoda.IoC.Core;
+using Agoda.IoC.ProjectUnderTest.Valid;
+using System;
+
+namespace Agoda.IoC.ProjectUnderTest.Valid2
+{
+
+    [RegisterTransient(ReplaceServices = true)]
+    public class ReplaceServiceTwoWork : IReplaceService
+    {
+
+        public string DoWork { get; set; } = nameof(ReplaceServiceTwoWork);
+    }
+}

--- a/src/ProjectsUnderTest/Agoda.IoC.ProjectUnderTest.Valid2/ValidRegistrations2.cs
+++ b/src/ProjectsUnderTest/Agoda.IoC.ProjectUnderTest.Valid2/ValidRegistrations2.cs
@@ -1,6 +1,5 @@
 ﻿using Agoda.IoC.Core;
 using Agoda.IoC.ProjectUnderTest.Valid;
-using System;
 
 namespace Agoda.IoC.ProjectUnderTest.Valid2
 {


### PR DESCRIPTION
Note:
  In case we have 2 modules  A and B. In A module we already registered `ReplaceServiceOneWork` to ServiceCollection as shown below
  ``` c# 
[RegisterTransient]
public class ReplaceServiceOneWork : IReplaceService
{
    public string DoWork { get; set; } = nameof(ReplaceServiceOneWork);
}
  ``` 
but in the B Module we need to replace `ReplaceServiceOneWork` to the new implementation `ReplaceServiceTwoWork`
In the B module agoda.ioc should provide the option to replace like below code

``` c# 
[RegisterTransient(ReplaceServices = true)]
public class ReplaceServiceTwoWork : IReplaceService
{
    public string DoWork { get; set; } = nameof(ReplaceServiceTwoWork);
}
```






