### PR TITLE
Change api to query types in assembly

### DIFF
--- a/src/Agoda.IoC.AutofacExt/AutoWireAssemblyExt.cs
+++ b/src/Agoda.IoC.AutofacExt/AutoWireAssemblyExt.cs
@@ -22,7 +22,7 @@ namespace Agoda.IoC.AutofacExt
             where T : ContainerRegistrationAttribute
         {
             var registrations = assemblies
-                .SelectMany(assembly => assembly.GetExportedTypes())
+                .SelectMany(assembly => AssemblyHelper.GetAllTypes(assembly))
                 .Where(type => type.IsClass)
                 .Select(type => new
                 {

--- a/src/Agoda.IoC.Core/AssemblyHelper.cs
+++ b/src/Agoda.IoC.Core/AssemblyHelper.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Agoda.IoC.Core
+{
+    public static class AssemblyHelper
+    {
+        public static IReadOnlyList<Type> GetAllTypes(Assembly assembly)
+        {
+            try
+            {
+                return assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                return ex.Types;
+            }
+        }
+    }
+}

--- a/src/Agoda.IoC.NetCore/StartupExtension.cs
+++ b/src/Agoda.IoC.NetCore/StartupExtension.cs
@@ -37,7 +37,7 @@ namespace Agoda.IoC.NetCore
             option?.Invoke(containerRegistrationOption);
 
             var registrations = assemblies
-                .SelectMany(assembly => assembly.GetExportedTypes())
+                .SelectMany(assembly => AssemblyHelper.GetAllTypes(assembly))
                 .Where(type => type.IsClass)
                 .Select(type => new
                 {

--- a/src/Agoda.IoC.Unity/UnityContainerAttributeExtensions.cs
+++ b/src/Agoda.IoC.Unity/UnityContainerAttributeExtensions.cs
@@ -61,7 +61,7 @@ namespace Agoda.IoC.Unity
         {
             // Look for all classes in the given assemblies that are decorated with a ContainerRegistrationAttribute
             var registrations = assemblies
-                .SelectMany(assembly => assembly.GetExportedTypes())
+                .SelectMany(assembly => AssemblyHelper.GetAllTypes(assembly))
                 .Where(type => type.IsClass)
                 .Select(type => new
                 {


### PR DESCRIPTION
Note:
assembly.GetExportedTypes() is not saved when consumer applications have many dependencies and deference versions. This API will throw FileNotFoundException without returning any Types 

In the others way, Using  assembly.GetTypes(); we can have a list of loadable type from `ReflectionTypeLoadException ex' by calling ex.Types
            

