### PR TITLE
Fix AssemblyHelper.GetAllTypes return null type

### DIFF
--- a/src/Agoda.IoC.AutofacExt/AutoWireAssemblyExt.cs
+++ b/src/Agoda.IoC.AutofacExt/AutoWireAssemblyExt.cs
@@ -23,7 +23,7 @@ namespace Agoda.IoC.AutofacExt
         {
             var registrations = assemblies
                 .SelectMany(assembly => AssemblyHelper.GetAllTypes(assembly))
-                .Where(type => type.IsClass)
+                .Where(type => type != null && type.IsClass)
                 .Select(type => new
                 {
                     ToType = type,

--- a/src/Agoda.IoC.NetCore/StartupExtension.cs
+++ b/src/Agoda.IoC.NetCore/StartupExtension.cs
@@ -38,7 +38,7 @@ namespace Agoda.IoC.NetCore
 
             var registrations = assemblies
                 .SelectMany(assembly => AssemblyHelper.GetAllTypes(assembly))
-                .Where(type => type.IsClass)
+                .Where(type => type != null && type.IsClass)
                 .Select(type => new
                 {
                     ToType = type,

--- a/src/Agoda.IoC.Unity/UnityContainerAttributeExtensions.cs
+++ b/src/Agoda.IoC.Unity/UnityContainerAttributeExtensions.cs
@@ -62,7 +62,7 @@ namespace Agoda.IoC.Unity
             // Look for all classes in the given assemblies that are decorated with a ContainerRegistrationAttribute
             var registrations = assemblies
                 .SelectMany(assembly => AssemblyHelper.GetAllTypes(assembly))
-                .Where(type => type.IsClass)
+                .Where(type => type != null && type.IsClass)
                 .Select(type => new
                 {
                     ToType = type,


### PR DESCRIPTION
```csharp
            var registrations = assemblies
                .SelectMany(assembly => AssemblyHelper.GetAllTypes(assembly))
                .Where(type => type.IsClass) // cause null reference exception
           
```