### PR TITLE
Adding interface namespace from external reference 

### DIFF
--- a/src/Agoda.IoC.sln
+++ b/src/Agoda.IoC.sln
@@ -73,7 +73,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Agoda.IoC.Generator.UnitTes
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Example", "Example", "{446BC7ED-88E1-4264-99FC-9FF7398F1618}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GeneratorExample", "Generator\Example\GeneratorExample\GeneratorExample.csproj", "{FC9C1FBB-B13E-41AD-889F-A883EBB5226F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GeneratorExample", "Generator\Example\GeneratorExample\GeneratorExample.csproj", "{FC9C1FBB-B13E-41AD-889F-A883EBB5226F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Generator/Agoda.IoC.Generator/RegistrationDescriptor.cs
+++ b/src/Generator/Agoda.IoC.Generator/RegistrationDescriptor.cs
@@ -131,14 +131,14 @@ internal class RegistrationDescriptor
                     var comma = new string(',', firstInterface.TypeArguments.Length - 1);
                     registrationContext.ForType = $"{firstInterface.Name}<{comma}>";
                     registrationContext.ConcreteType = $"{_registrationSymbol.Name}<{comma}>";
-                    registrationContext.IsOpenGeneric = true;
-                    NameSpaces.Add(firstInterface!.ContainingNamespace.ToDisplayString());
+                    registrationContext.IsOpenGeneric = true;                    
                 }
                 else
                 {
                     registrationContext.ForType = firstInterface.Name;
                     registrationContext.ConcreteType = _registrationSymbol.Name;
-                } 
+                }
+                NameSpaces.Add(firstInterface!.ContainingNamespace.ToDisplayString());
                 NameSpaces.Add(_registrationSymbol!.ContainingNamespace.ToDisplayString());
                 RegistrationContexts.Add(registrationContext);
             }

--- a/src/Generator/Example/GeneratorExample/Example1.cs
+++ b/src/Generator/Example/GeneratorExample/Example1.cs
@@ -126,3 +126,17 @@ public class DoWork<T> where T : new()
         return new T();
     }
 }
+
+[RegisterSingleton]
+public class GenericeDoWork<T> : IDoWork<T> where T : new ()
+{
+
+    public T Process()
+    {
+        return new T();
+    }
+}
+public interface IDoWork<T> where T : new()
+{
+    T Process();
+}

--- a/src/Generator/Example/GeneratorExample/Example1.cs
+++ b/src/Generator/Example/GeneratorExample/Example1.cs
@@ -1,10 +1,11 @@
 ﻿using Agoda.IoC.Generator.Abstractions;
+using GeneratorExample.Interfaces;
 using Microsoft.Extensions.Hosting;
 
 namespace GeneratorExample;
 
 
-[RegisterHostedService] 
+[RegisterHostedService]
 public class TimedHostedService : IHostedService, IDisposable
 {
     private int executionCount = 0;
@@ -40,7 +41,7 @@ public class TimedHostedService : IHostedService, IDisposable
 
 
 
-[RegisterScoped(Concrete = true)]
+[RegisterScoped]
 public class ClassA : IClassA
 {
 }
@@ -49,7 +50,7 @@ public class ClassA : IClassA
 public class ClassB : IClassA
 {
 }
-public interface IClassA { }
+
 
 
 [RegisterSingleton(Factory = typeof(ClassBImplementationFactory))]
@@ -96,27 +97,25 @@ public interface IPipeline
     string Invoke();
 }
 [RegisterSingleton(For = typeof(IMiddleware), OfCollection = true, Order = 3)]
-public class IMiddleware2 : IMiddleware
+public class Middleware2 : IMiddleware
 {
     public string Invoke()
     {
-        return nameof(IMiddleware1);
+        return nameof(Middleware2);
     }
 }
 [RegisterSingleton(For = typeof(IMiddleware), OfCollection = true, Order = 5)]
-public class IMiddleware1 : IMiddleware
+public class Middleware1 : IMiddleware
 {
     public string Invoke()
     {
-        return nameof(IMiddleware1);
+        return nameof(Middleware1);
     }
 }
 public interface IMiddleware
 {
     string Invoke();
 }
-
-
 
 
 [RegisterSingleton]

--- a/src/Generator/Example/GeneratorExample/Example1.cs
+++ b/src/Generator/Example/GeneratorExample/Example1.cs
@@ -128,7 +128,7 @@ public class DoWork<T> where T : new()
 }
 
 [RegisterSingleton]
-public class GenericeDoWork<T> : IDoWork<T> where T : new ()
+public class GenericDoWork<T> : IDoWork<T> where T : new ()
 {
 
     public T Process()

--- a/src/Generator/Example/GeneratorExample/GeneratorExample.csproj
+++ b/src/Generator/Example/GeneratorExample/GeneratorExample.csproj
@@ -14,7 +14,7 @@
 		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
 
 		<ProjectReference Include="..\..\Agoda.IoC.Generator.Abstractions\Agoda.IoC.Generator.Abstractions.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true" />
-		<ProjectReference Include="..\..\Agoda.IoC.Generator\Agoda.IoC.Generator.csproj"  OutputItemType="Analyzer" ReferenceOutputAssembly="true"/>
+		<ProjectReference Include="..\..\Agoda.IoC.Generator\Agoda.IoC.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true" />
 	</ItemGroup>
 
 </Project>

--- a/src/Generator/Example/GeneratorExample/Interfaces/IClassA.cs
+++ b/src/Generator/Example/GeneratorExample/Interfaces/IClassA.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GeneratorExample.Interfaces;
+
+public interface IClassA { }

--- a/src/Generator/UnitTests/Agoda.IoC.Generator.UnitTests/ContainerRegistrationGenerator.MixLifetime.UnitTests.cs
+++ b/src/Generator/UnitTests/Agoda.IoC.Generator.UnitTests/ContainerRegistrationGenerator.MixLifetime.UnitTests.cs
@@ -124,7 +124,7 @@ return serviceCollection;
 namespace Agoda.IoC.Generator.UnitTests;
 
 [RegisterSingleton]
-public class GenericeDoWork<T> : IDoWork<T> where T : new ()
+public class GenericDoWork<T> : IDoWork<T> where T : new ()
 {
 
     public T Process()
@@ -137,7 +137,7 @@ public interface IDoWork<T> where T : new()
     T Process();
 }
 ",
-    @"serviceCollection.AddSingleton(typeof(IDoWork<>), typeof(GenericeDoWork<>));
+    @"serviceCollection.AddSingleton(typeof(IDoWork<>), typeof(GenericDoWork<>));
 return serviceCollection;
 ")]
 

--- a/src/Generator/UnitTests/Agoda.IoC.Generator.UnitTests/ContainerRegistrationGenerator.MixLifetime.UnitTests.cs
+++ b/src/Generator/UnitTests/Agoda.IoC.Generator.UnitTests/ContainerRegistrationGenerator.MixLifetime.UnitTests.cs
@@ -110,7 +110,7 @@ serviceCollection.AddSingleton(typeof(DoWork<>));
 return serviceCollection;
 ")]
 
-    public void Should_Generate_With_First_interface_Correctly(string source, string generatedBodyMethod)
+    public void Should_Generate_With_Typof_Correctly(string source, string generatedBodyMethod)
     {
         TestHelper.GenerateAgodaIoC(source)
                 .Should()
@@ -119,6 +119,35 @@ return serviceCollection;
                 .HaveMethodBody("Register", generatedBodyMethod);
     }
 
+    [TestCase(
+    @"using using Agoda.IoC.Generator.Abstractions;
+namespace Agoda.IoC.Generator.UnitTests;
 
+[RegisterSingleton]
+public class GenericeDoWork<T> : IDoWork<T> where T : new ()
+{
+
+    public T Process()
+    {
+        return new T();
+    }
+}
+public interface IDoWork<T> where T : new()
+{
+    T Process();
+}
+",
+    @"serviceCollection.AddSingleton(typeof(IDoWork<>), typeof(GenericeDoWork<>));
+return serviceCollection;
+")]
+
+    public void Should_Generate_With_First_interface_Correctly(string source, string generatedBodyMethod)
+    {
+        TestHelper.GenerateAgodaIoC(source)
+                .Should()
+                .HaveMethodCount(2)
+                .HaveMethods("Register", "RegisterFromAgodaIoCGeneratorUnitTests")
+                .HaveMethodBody("Register", generatedBodyMethod);
+    }
 
 }

--- a/src/Generator/UnitTests/Agoda.IoC.Generator.UnitTests/ContainerRegistrationGenerator.MixLifetime.UnitTests.cs
+++ b/src/Generator/UnitTests/Agoda.IoC.Generator.UnitTests/ContainerRegistrationGenerator.MixLifetime.UnitTests.cs
@@ -110,7 +110,7 @@ serviceCollection.AddSingleton(typeof(DoWork<>));
 return serviceCollection;
 ")]
 
-    public void Should_Generate_With_Typof_Correctly(string source, string generatedBodyMethod)
+    public void Should_Generate_With_TypeOf_Correctly(string source, string generatedBodyMethod)
     {
         TestHelper.GenerateAgodaIoC(source)
                 .Should()


### PR DESCRIPTION
This pull request resolves the issue with the generated registration code by incorporating the interface namespace from an external or nested namespace within the same project or external project when the consumer not provide `For` attribute for the interface or  using `Concrete = false.`
Bug Found :
``` csharp
// interface 
namespace GeneratorExample.Interfaces; // nested namespace
public interface IClassA { }

// implementation code
namespace GeneratorExample;
// case 1
[RegisterScoped]
public class ClassA : IClassA
{
}
// case 2
[RegisterScoped(Concrete = false)]
public class ClassB : IClassA
{
}
```
Before this fix, the generated code did not include the using GeneratorExample.Interfaces statement.

``` csharp
using Microsoft.Extensions.DependencyInjection.Extensions;
using GeneratorExample;
namespace Microsoft.Extensions.DependencyInjection
{
    public static class AgodaIoCGeneratorInjectServiceCollectionExtension
    {
        public static IServiceCollection RegisterFromGeneratorExample(this IServiceCollection serviceCollection)
        {
            return Register(serviceCollection);
        }

        internal static IServiceCollection Register(this IServiceCollection serviceCollection)
        {
	      serviceCollection.AddScoped<IClassA, ClassB>();	
             return serviceCollection;
        }
    }
}

```
the absence of the` using GeneratorExample.Interfaces` statement in the generated code caused a compilation error.

Fixing code : 
``` csharp
using Microsoft.Extensions.DependencyInjection.Extensions;
using GeneratorExample;
using GeneratorExample.Interfaces; // included

namespace Microsoft.Extensions.DependencyInjection
{
    public static class AgodaIoCGeneratorInjectServiceCollectionExtension
    {
        public static IServiceCollection RegisterFromGeneratorExample(this IServiceCollection serviceCollection)
        {
            return Register(serviceCollection);
        }

        internal static IServiceCollection Register(this IServiceCollection serviceCollection)
        {
		...
		serviceCollection.AddScoped<IClassA, ClassA>();
                return serviceCollection;
        }
    }
}
```