### PR TITLE
Make RegisterKeyedFactory public

### DIFF
--- a/src/Agoda.IoC.NetCore/StartupExtension.cs
+++ b/src/Agoda.IoC.NetCore/StartupExtension.cs
@@ -129,7 +129,7 @@ namespace Agoda.IoC.NetCore
             }
         }
 
-        private static void RegisterKeyedFactory(this IServiceCollection services, IDictionary<Type, List<KeyTypePair>> keysForTypes)
+        public static void RegisterKeyedFactory(this IServiceCollection services, IDictionary<Type, List<KeyTypePair>> keysForTypes)
         {
             foreach (var key in keysForTypes)
             {


### PR DESCRIPTION
We exposed `AutoWireAssembly<T>()` for constructing `keysForType` dictionary for keyed DI,  
but didn't expose `RegisterKeyedFactory()` to actually register them.